### PR TITLE
ANALYTICS-1865 Enhance campaigns overview documentation

### DIFF
--- a/source/includes/_campaigns_overview_report.md
+++ b/source/includes/_campaigns_overview_report.md
@@ -4,12 +4,12 @@
 
 | Method | URI Format |
 |---|---|
-| GET | /client_reports/campaigns_overview/[gmaid]?[query_params] |
+| GET | /client_reports/campaigns_overview/[gmaid]|
 
 #### Usage
 Use GET to retrieve information for the Campaigns Overview report.
 
-The data returned will include campaign performance metrics for the last 30 days and a campaign list with additional details and breakdowns per cycle.
+The data returned will include campaign performance metrics for the last 30 days and a campaign list with additional details and breakdowns per cycle.  Campaign are limitted to those that have had activity within the previous year.  This means that a campaign that ended 13 months prior will not be included in the campaign list section.
 
 The performance metrics for the last 30 days are across all active campaigns and will include:
 

--- a/source/includes/_campaigns_overview_report.md
+++ b/source/includes/_campaigns_overview_report.md
@@ -9,11 +9,11 @@
 #### Usage
 Use GET to retrieve information for the Campaigns Overview report.
 
-The data returned will include campaign performance metrics for the last 30 days and a campaign list with additional details and breakdowns per cycle.  Campaign are limitted to those that have had activity within the previous year.  This means that a campaign that ended 13 months prior will not be included in the campaign list section.
+The data returned will include campaign performance metrics for the last 30 days and a campaign list with additional details and breakdowns per cycle.  Campaign are limited to those that have had activity within the previous year.  This means that a campaign that ended 13 months prior will not be included in the campaign list section.
 
 The performance metrics for the last 30 days are across all active campaigns and will include:
 
-- Total Impresssions
+- Total Impressions
 - Total Clicks
 - Total Calls
 - Total Emails


### PR DESCRIPTION
**References**: [ANALYTICS-1865](https://tickets.reachlocal.com/browse/ANALYTICS-1865)

**Description**:
The documentation for the [campaigns overview endpoint](https://reachlocal.github.io/api-docs/#campaigns-overview-report) says that it includes activity for the previous 30 days, but it doesn't mention how it limits campaigns and cycles to those that have had activity in the previous year.  Update the documentation to clearly explain this limitation.

This endpoint does accept a start_date parameter, but we don't want to encourage usage of this feature due to performance concerns so we are not publishing it.

**Testing Instructions**:
Verify that the documentation changes are correct and don't contain any spelling or other grammar errors.