### PR TITLE
Remove NanoRep from CEEA documentation.

### DIFF
--- a/source/includes/_capture_external_event_api.md
+++ b/source/includes/_capture_external_event_api.md
@@ -30,7 +30,7 @@ This section defines the data parameter JSON hash.
 
 Data Field | Required | Datatype | Nullable | Description
 --------- | -------- | -------- | -------- | -----------
-provider | yes | string | no | The name of the service provider i.e. Nanorep.
+provider | yes | string | no | The name of the service provider.
 visitId | yes | string | no | The Reach Local visitId of the chat user.
 chatDuration | yes | number | yes | The duration of the chat in seconds.
 chatSummary | yes | string | no | A summary of the chat.
@@ -56,7 +56,7 @@ curl -X POST \
   "accountId": "123456789",
   "data":  
     {
-        "provider": "NanoRep",
+        "provider": "SomeCompany",
         "visitId": "bd4567f4-9b90-42e6-b282-7767af1ba581",          
         "chatDuration": 261.58,
         "chatSummary": "Do you have any specials going on?",
@@ -118,7 +118,7 @@ request = Net::HTTP::Post.new(url)
 request["accept"] = 'application/json'
 request["authorization"] = 'Bearer OAUTH_ACCESS_TOKEN'
 request["Content-Type"] = 'application/json'
-request.body = "{\n  \"eventTime\": \"2017-03-10T01:19:23Z\",\n  \"accountId\": \"123456789\",\n  \"data\":  \n    {\n        \"provider\": \"NanoRep\",\n        \"visitId\": \"bd4567f4-9b90-42e6-b282-7767af1ba581\",          \n        \"chatDuration\": 261.58,\n        \"chatSummary\": \"Do you have any specials going on?\",\n        \"chatTextFull\": \"\u000a[2/13/2017 10:55:24 AM] elaine: Hello, thanks for contacting St. Louis Car Dealership. My name is elaine, may I have your name?\u000a  [3/9/2017 8:17:50 PM] System: All users have left the chat.\",\n        \"chatVisitorEmail\": \"minneapple@gmail.com\",\n        \"chatVisitorName\": \"Bob\",\n        \"chatVisitorPhone\": \"6592009999\"\n    }\n       \n}\n"
+request.body = "{\n  \"eventTime\": \"2017-03-10T01:19:23Z\",\n  \"accountId\": \"123456789\",\n  \"data\":  \n    {\n        \"provider\": \"SomeCompany\",\n        \"visitId\": \"bd4567f4-9b90-42e6-b282-7767af1ba581\",          \n        \"chatDuration\": 261.58,\n        \"chatSummary\": \"Do you have any specials going on?\",\n        \"chatTextFull\": \"\u000a[2/13/2017 10:55:24 AM] elaine: Hello, thanks for contacting St. Louis Car Dealership. My name is elaine, may I have your name?\u000a  [3/9/2017 8:17:50 PM] System: All users have left the chat.\",\n        \"chatVisitorEmail\": \"minneapple@gmail.com\",\n        \"chatVisitorName\": \"Bob\",\n        \"chatVisitorPhone\": \"6592009999\"\n    }\n       \n}\n"
 
 response = http.request(request)
 puts response.read_body
@@ -133,7 +133,7 @@ puts response.read_body
 OkHttpClient client = new OkHttpClient();
 
 MediaType mediaType = MediaType.parse("application/json");
-RequestBody body = RequestBody.create(mediaType, "{\n  \"eventTime\": \"2017-03-10T01:19:23Z\",\n  \"accountId\": \"1213456789\",\n  \"data\":  \n    {\n        \"provider\": \"NanoRep\",\n        \"visitId\": \"bd4567f4-9b90-42e6-b282-7767af1ba581\",          \n        \"chatDuration\": 261.58,\n        \"chatSummary\": \"Do you have any specials going on?\",\n        \"chatTextFull\": \"\u000a[2/13/2017 10:55:24 AM] elaine: Hello, thanks for contacting St. Louis Car Dealership. My name is elaine, may I have your name?\u000a  [3/9/2017 8:17:50 PM] System: All users have left the chat.\",\n        \"chatVisitorEmail\": \"minneapple@gmail.com\",\n        \"chatVisitorName\": \"Bob\",\n        \"chatVisitorPhone\": \"6592009999\"\n    }\n       \n}\n");
+RequestBody body = RequestBody.create(mediaType, "{\n  \"eventTime\": \"2017-03-10T01:19:23Z\",\n  \"accountId\": \"1213456789\",\n  \"data\":  \n    {\n        \"provider\": \"SomeCompany\",\n        \"visitId\": \"bd4567f4-9b90-42e6-b282-7767af1ba581\",          \n        \"chatDuration\": 261.58,\n        \"chatSummary\": \"Do you have any specials going on?\",\n        \"chatTextFull\": \"\u000a[2/13/2017 10:55:24 AM] elaine: Hello, thanks for contacting St. Louis Car Dealership. My name is elaine, may I have your name?\u000a  [3/9/2017 8:17:50 PM] System: All users have left the chat.\",\n        \"chatVisitorEmail\": \"minneapple@gmail.com\",\n        \"chatVisitorName\": \"Bob\",\n        \"chatVisitorPhone\": \"6592009999\"\n    }\n       \n}\n");
 Request request = new Request.Builder()
   .url("https://api.reachlocalservices.com/capture_events/chats")
   .post(body)


### PR DESCRIPTION
I feel it's inapropriate to provide a partener with API
documentation that potentially includes the name of a
competitor.