### PR TITLE
Capture Discovery time zone clarity

### DIFF
--- a/source/includes/_capture_discovery.md
+++ b/source/includes/_capture_discovery.md
@@ -228,8 +228,8 @@ When using the GET method, the results can be filtered using these parameters:
 
 | Param     | Required | Function |
 |-----------|-----|---|
-| startTime | Yes | Restricts the results to those occurring on or after this date and time. |
-| endTime   | Yes | Restricts the results to those occurring on or before this date and time. |
+| startTime | Yes | Restricts the results to those occurring on or after this date and time. If time is not specified, startTime will be the beginning of the day in UTC (T00:00:00Z). |
+| endTime   | Yes | Restricts the results to those occurring on or before this date and time. If time is not specified, endTime will be the end of the day in UTC (T12:59:59Z). |
 | gmaid     | Yes | Restrict results to the specified advertiser |
 | bucket    | No  | place results in buckets |
 


### PR DESCRIPTION
Clarifies the default time zone that will be used for the Capture Discovery report.